### PR TITLE
Default to custom build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start-consuming-api": "node dist/js/src/readEnergyGeneration.js",
     "import-irec-assets": "node dist/js/src/importIRECAssets.js",
     "fund-assets-smart-meters": "node dist/js/src/fundAssets.js",
-    "build": "tsc",
+    "build-ts": "tsc",
+    "build": "node scripts/build.js",
     "prettier": "prettier --write --config-precedence file-override './src/**/*'",
     "lint": "./node_modules/.bin/tslint 'src/**/*{.ts,.tsx}'",
     "lint-fix": "./node_modules/.bin/tslint --fix 'src/**/*{.ts,.tsx}'"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -51,7 +51,7 @@ async function run() {
 
   await fs.ensureDir(`${ROOT_DIRECTORY}/dist/js`);
 
-  await executeCommand('npm run build', ROOT_DIRECTORY)
+  await executeCommand('npm run build-ts', ROOT_DIRECTORY)
 
   if (!(await fs.pathExists(`${ROOT_DIRECTORY}/dist/js/src`))) {
     await fs.move(`${ROOT_DIRECTORY}/dist/js`, `${ROOT_DIRECTORY}/dist/js-temp`);


### PR DESCRIPTION
Uses `build.js` when executing `npm run build` to ensure all files in correct locations.